### PR TITLE
fix!: Change the package name of the client tool to "crw"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "crw"
+version = "0.1.0"
+dependencies = [
+ "async-stream",
+ "clap",
+ "futures-core",
+ "futures-util",
+ "hyper",
+ "hyperlocal",
+ "is-terminal",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,22 +857,3 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "workspace"
-version = "0.1.0"
-dependencies = [
- "async-stream",
- "clap",
- "futures-core",
- "futures-util",
- "hyper",
- "hyperlocal",
- "is-terminal",
- "serde",
- "serde_json",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "url",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "workspace"
+name = "crw"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
The package name specified by "cargo install" was unclear.

before:
```
cargo install --git https://github.com/hankei6km/vscode-ext-serve-run-wasm.git workspace
```

after:
```
cargo install --git https://github.com/hankei6km/vscode-ext-serve-run-wasm.git crw
```