### PR TITLE
fix!: Change parameter name delimiter to "-" from "_"

### DIFF
--- a/src/client/src/lib.rs
+++ b/src/client/src/lib.rs
@@ -128,7 +128,7 @@ fn build_url(run_args: RunArgs) -> Url {
         run_args.memory_maximum.to_string(),
         "--memory-shared".to_string(),
         run_args.memory_shared.to_string(),
-        "--force_exit_after_n_seconds_stdin_is_closed".to_string(),
+        "--force-exit-after-n-seconds-stdin-is-closed".to_string(),
         run_args
             .force_exit_after_n_seconds_stdin_is_closed
             .to_string(),
@@ -165,7 +165,7 @@ mod test_build_url {
         let url = build_url(args);
         assert_eq!(
             url.as_str(),
-            "http://localhost:3000/run?args=%5B%22--memory-initial%22%2C%221%22%2C%22--memory-maximum%22%2C%222%22%2C%22--memory-shared%22%2C%22true%22%2C%22--force_exit_after_n_seconds_stdin_is_closed%22%2C%220%22%2C%22--cwd%22%2C%22%2Fpath%2Fto%22%2C%22--%22%2C%22test1.wasm%22%2C%22--foo%22%2C%22bar%22%5D"
+            "http://localhost:3000/run?args=%5B%22--memory-initial%22%2C%221%22%2C%22--memory-maximum%22%2C%222%22%2C%22--memory-shared%22%2C%22true%22%2C%22--force-exit-after-n-seconds-stdin-is-closed%22%2C%220%22%2C%22--cwd%22%2C%22%2Fpath%2Fto%22%2C%22--%22%2C%22test1.wasm%22%2C%22--foo%22%2C%22bar%22%5D"
         );
     }
 }

--- a/src/client/test/scripts/test_cli.sh
+++ b/src/client/test/scripts/test_cli.sh
@@ -27,7 +27,7 @@ cat "${ERR_FILE}"
 echo ""
 
 diff <(echo -n '/run') "${OUT_FILE}"
-diff <(echo -n '["--memory-initial","100","--memory-maximum","100","--memory-shared","true","--force_exit_after_n_seconds_stdin_is_closed","0","--cwd","'"${PWD}"'","--","test.wasm"]') "${ERR_FILE}"
+diff <(echo -n '["--memory-initial","100","--memory-maximum","100","--memory-shared","true","--force-exit-after-n-seconds-stdin-is-closed","0","--cwd","'"${PWD}"'","--","test.wasm"]') "${ERR_FILE}"
 
 
 # TODO: リクエストが実行される前にテストが落ちるとサーバーが稼働したままになる.後処理を検討.

--- a/src/extension/lib/handleRun.ts
+++ b/src/extension/lib/handleRun.ts
@@ -72,9 +72,9 @@ export class HandleRun implements IpcHandler {
       }
       if (
         typeof request.args.runArgs[
-          'force_exit_after_n_seconds_stdin_is_closed'
+          'force-exit-after-n-seconds-stdin-is-closed'
         ] === 'number' &&
-        request.args.runArgs['force_exit_after_n_seconds_stdin_is_closed'] > 0
+        request.args.runArgs['force-exit-after-n-seconds-stdin-is-closed'] > 0
       ) {
         ;(async () => {
           // https://github.com/microsoft/vscode-wasm/issues/110
@@ -103,7 +103,7 @@ export class HandleRun implements IpcHandler {
                 resolve,
                 1000 *
                   request.args.runArgs[
-                    'force_exit_after_n_seconds_stdin_is_closed'
+                    'force-exit-after-n-seconds-stdin-is-closed'
                   ]
               )
             )


### PR DESCRIPTION
That change is for IPC parameters, so it does not affect command line
operations.

BREAKING CHANGE: The IPC server no longer accepts the "force_exit_after_n_seconds_stdin_is_closed" parameter. Instead, it accepts "force-exit-after-n-seconds-stdin-is-closed".